### PR TITLE
Maven Wrapper Script Fix

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -230,4 +230,4 @@ exec "$JAVACMD" \
   $MAVEN_OPTS \
   -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
   "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
-  ${WRAPPER_LAUNCHER} "$@"
+  ${WRAPPER_LAUNCHER} $MAVEN_CMD_LINE_ARGS

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -80,7 +80,7 @@ goto error
 
 :init
 
-set MAVEN_CMD_LINE_ARGS=%*
+set MAVEN_CMD_LINE_ARGS=%MAVEN_CONFIG% %*
 
 @REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
 @REM Fallback to current working directory if not found.
@@ -118,7 +118,7 @@ for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do s
 
 SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 
-set WRAPPER_JAR="".\.mvn\wrapper\maven-wrapper.jar""
+set WRAPPER_JAR=""%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar""
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
 %MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CMD_LINE_ARGS%


### PR DESCRIPTION
Updated mvnw scripts with latest version which property passes the MAVEN_CONFIG env var.  This env is very useful in CI pipelines to dynamically pass maven config values (ex: -s path/to/settings.xml) to the mvnw script.
